### PR TITLE
Add support for Demagnetize mod and conveyors to the Electromagnet

### DIFF
--- a/src/main/java/gtclassic/item/GTItemElectromagnet.java
+++ b/src/main/java/gtclassic/item/GTItemElectromagnet.java
@@ -83,6 +83,9 @@ public class GTItemElectromagnet extends BasicElectricItem implements IAdvancedT
 			int pulled = 0;
 			for (EntityItem item : worldIn.getEntitiesWithinAABB(EntityItem.class, new AxisAlignedBB(x, y, z, x + 1, y
 					+ 1, z + 1).grow(range))) {
+				if (item.getEntityData().getBoolean("PreventRemoteMovement")) {
+					continue;
+				}
 				if (!canPull(stack) || pulled > 200) {
 					break;
 				}


### PR DESCRIPTION
Immersive Engineering's conveyors (and [my Demagnetize mod](https://minecraft.curseforge.com/projects/demagnetize)) add the PreventRemoteMovement boolean NBT tag to the item. This prevents them from being picked up by magnets.