### PR TITLE
made hot materials use ON_FIRE damage source instead of IN_FIRE damage source

### DIFF
--- a/src/main/java/gtclassic/api/material/GTMaterialItemHot.java
+++ b/src/main/java/gtclassic/api/material/GTMaterialItemHot.java
@@ -34,7 +34,7 @@ public class GTMaterialItemHot extends GTMaterialItem {
 			EntityLivingBase player = (EntityLivingBase) entityIn;
 			if (!ItemHazmatArmor.isFullHazmatSuit(player) && !player.isImmuneToFire()
 					&& !GTUtility.hasFullQuantumSuit(player)) {
-				entityIn.attackEntityFrom(DamageSource.IN_FIRE, 4.0F);
+				entityIn.attackEntityFrom(DamageSource.ON_FIRE, 1.0F);
 			}
 		}
 	}


### PR DESCRIPTION
also quartered damage received as a result.
Reason I did this is cause of how with a nano suit holding a hot ingot literally does ABSOLUTELY FUCK ALL NOTHING, just ticks you